### PR TITLE
points2nearestcell: add drop=FALSE to new.coords

### DIFF
--- a/R/points2nearestcell.R
+++ b/R/points2nearestcell.R
@@ -78,7 +78,7 @@ points2nearestcell <- function(locs = NULL,
     # find the nearest raster cell for each point with missing data
     nearest.cell <- class::knn1(coord.ras, coord.miss, cell.id)
 
-    new.coords <- coord.ras[nearest.cell, ]
+    new.coords <- coord.ras[nearest.cell, , drop = FALSE]
     colnames(new.coords) <- c("X_new", "Y_new")
     new.coords <- as.data.frame(new.coords)
 


### PR DESCRIPTION
Otherwise, when there's only one point to move, the function fails at `colnames(new.coords) <- c("X_new", "Y_new")`, because (without `drop=FALSE`) `new.coords` is a vector hence has no columns:

```
library(terra)
library(rSDM)

r <- rast(system.file("ex/elev.tif", package = "terra"))

coords <- data.frame(
  x = c(6.129, 6.004, 6.0208, 5.9875, 5.9458),
  y = c(50.1708, 50.1792, 50.1792, 50.1625, 50.1708)
)

pts <- vect(as.matrix(coords), crs = crs(r))

rSDM::points2nearestcell(pts, r)  # OK
rSDM::points2nearestcell(pts[-1, ], r)  # error
```